### PR TITLE
allow_web_editing is true by default

### DIFF
--- a/_config/dnroot.yml
+++ b/_config/dnroot.yml
@@ -31,3 +31,5 @@ Injector:
     properties: 
       BaseDir: "../deploynaut-resources/build-cache"
       CacheSize: 5
+DNEnvironment:
+    allow_web_editing: true


### PR DESCRIPTION
This was a blocker for initial setup of deploynaut. As environment configuration files won't get created
